### PR TITLE
Fix wrong game over alert

### DIFF
--- a/index.js
+++ b/index.js
@@ -448,6 +448,7 @@ class BackgroundBlocksController {
     for (let i = y; i > 0; i--) {
       this.backgroundBlocks.blocks[i] = this.backgroundBlocks.blocks[i - 1];
     }
+    this.backgroundBlocks.blocks[0] = [];
   }
 }
 


### PR DESCRIPTION
The error was not ```GameOverChecker``` or ```BackgroundBlocksController.addTetrominoToBackground(currentTetromino)``` fault , the bug was caused by ```BackgroundBlocksController.removeLine(y)```: top row reference was being duplicated when a full row was eliminated.

Closes #8 